### PR TITLE
Fix submodules branches

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -9,8 +9,18 @@ services:
       - "8082:8080"
     networks:
       - voyage
+  recommendations_cache:
+    ports:
+      - "6379:6379"
+    networks:
+      - voyage
   place-wrapper:
     ports:
       - "8083:8080"
+    networks:
+      - voyage
+  place_wrapper_cache:
+    ports:
+      - "6380:6379"
     networks:
       - voyage


### PR DESCRIPTION
The submodules for each of the orchestrator main branches (main and dev) should be in the respective branch