### PR TITLE
VOYAGE-220 Fix env variables not being piped into frontend

### DIFF
--- a/config.env
+++ b/config.env
@@ -1,2 +1,5 @@
 RECOMMENDATION_SERVICE_URL=http://recommendation-service:8080/process
 MONGO_USER=voyage
+SUPABASE_URL=https://mchipwwninhldjiuzhlw.supabase.co
+SUPABASE_AVATAR_BUCKET=avatar-bucket
+SUPABASE_BANNER_BUCKET=banner-bucket


### PR DESCRIPTION
This pull request introduces support for Supabase integration by adding new environment variables and updating the secret-fetching script to handle Supabase-related secrets. The changes also include creating a frontend-specific `.env` file for Vite environment variables.

### Supabase Integration:

* [`config.env`](diffhunk://#diff-42603c88c3bea3803b6b21c11507ad107047ce8a242c0ad52f295ff560d8693fR3-R5): Added `SUPABASE_URL`, `SUPABASE_AVATAR_BUCKET`, and `SUPABASE_BANNER_BUCKET` environment variables to support Supabase configuration.
* [`fetch-secrets.sh`](diffhunk://#diff-e4cc17073bf1164af20ab88691a33933a47891819b20c2caeee3e453f22e8829L7-R30): Updated the script to include Supabase-related secrets (`SUPABASE_SERVICE_ROLE_KEY` and `SUPABASE_KEY`) in the secret mappings and to generate a frontend-specific `.env` file with Vite-compatible variables (`VITE_APP_GOOGLE_MAPS_API_KEY`, `VITE_SUPABASE_URL`, and `VITE_SUPABASE_ANON_KEY`).