### PR TITLE
Fix docker-compose missing user-management

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -3,6 +3,7 @@ include:
   - recommendations/docker-compose.yaml
   - place-wrapper/docker-compose.yaml
   - maps-wrapper/docker-compose.yaml
+  - user-management/docker-compose.yaml
 
 services:
   reverse-proxy:
@@ -20,6 +21,7 @@ services:
       - place-wrapper
       - maps-wrapper
       - maps_wrapper_cache
+      - user-management
 
 networks:
   voyage:


### PR DESCRIPTION
This pull request updates the `docker-compose.prod.yaml` file to include a new service for user management. The most important changes are as follows:

Updates to `docker-compose.prod.yaml`:

* Added the `user-management/docker-compose.yaml` file to the `include:` section, enabling the configuration for the user management service.
* Added `user-management` to the `services:` section, integrating it into the list of services managed by the Docker Compose file.