### PR TITLE
Fix supabase_url fetching

### DIFF
--- a/fetch-secrets.sh
+++ b/fetch-secrets.sh
@@ -23,8 +23,10 @@ do
   echo "$ENV_NAME=$SECRET_VALUE" >> .env
 done
 
+SUPABASE_URL=$(grep "SUPABASE_URL" .env | cut -d '=' -f2-)
+
 # Create frontend .env file with Vite environment variables
 echo "# Frontend Environment Variables" > ./frontend/ui/.env
 echo "VITE_APP_GOOGLE_MAPS_API_KEY=$(az keyvault secret show --name GOOGLEMAPSAPIKEY --vault-name $KEYVAULT_NAME --query "value" -o tsv)" >> ./frontend/ui/.env
-echo "VITE_SUPABASE_URL=$(az keyvault secret show --name SUPABASEURL --vault-name $KEYVAULT_NAME --query "value" -o tsv)" >> ./frontend/ui/.env
+echo "VITE_SUPABASE_URL=$SUPABASE_URL" >> ./frontend/ui/.env
 echo "VITE_SUPABASE_ANON_KEY=$(az keyvault secret show --name SUPABASEKEY --vault-name $KEYVAULT_NAME --query "value" -o tsv)" >> ./frontend/ui/.env


### PR DESCRIPTION
This pull request modifies the `fetch-secrets.sh` script to streamline the handling of the `SUPABASE_URL` environment variable by reusing a previously extracted value instead of making an additional call to the Azure Key Vault.

### Improvements to environment variable handling:

* [`fetch-secrets.sh`](diffhunk://#diff-e4cc17073bf1164af20ab88691a33933a47891819b20c2caeee3e453f22e8829R26-R31): Extracted the `SUPABASE_URL` value from the `.env` file using `grep` and reused it to populate the `VITE_SUPABASE_URL` variable in the frontend `.env` file, reducing redundant calls to the Azure Key Vault.