### PR TITLE
Add user-management to reverse-proxy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ include:
   - place-wrapper/docker-compose.yaml
   - maps-wrapper/docker-compose.yaml
   - frontend/docker-compose.yml
+  - user-management/docker-compose.yaml
 
 services:
   reverse-proxy:
@@ -22,6 +23,7 @@ services:
       - recommendations
       - place-wrapper
       - maps-wrapper
+      - user-management
 
 networks:
   voyage:

--- a/nginx.conf
+++ b/nginx.conf
@@ -88,6 +88,14 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location /api/v1/user-management/ {
+            proxy_pass http://user-management:8080/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
 
         error_page 404 /404.html;
         location = /404.html {


### PR DESCRIPTION
This pull request introduces changes to integrate a new `user-management` service into the existing system. The updates include modifications to the `docker-compose.yaml` file to add the service and updates to the `nginx.conf` file to route requests to the new service.

### Integration of `user-management` service:

* **`docker-compose.yaml`:**
  - Added `user-management/docker-compose.yaml` to the `include` section to include the new service configuration.
  - Added `user-management` to the `services` section to register the service in the Docker Compose setup.

* **`nginx.conf`:**
  - Added a new location block under `http` to route requests to `/api/v1/user-management/` to the `user-management` service running on port 8080. This includes setting appropriate proxy headers.