### PR TITLE
Add user-managent to reverse-proxy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ include:
   - place-wrapper/docker-compose.yaml
   - maps-wrapper/docker-compose.yaml
   - frontend/docker-compose.yml
+  - user-management/docker-compose.yaml
 
 services:
   reverse-proxy:
@@ -22,6 +23,7 @@ services:
       - recommendations
       - place-wrapper
       - maps-wrapper
+      - user-management
 
 networks:
   voyage:

--- a/fetch-secrets.sh
+++ b/fetch-secrets.sh
@@ -23,8 +23,10 @@ do
   echo "$ENV_NAME=$SECRET_VALUE" >> .env
 done
 
+SUPABASE_URL=$(grep "SUPABASE_URL" .env | cut -d '=' -f2-)
+
 # Create frontend .env file with Vite environment variables
 echo "# Frontend Environment Variables" > ./frontend/ui/.env
 echo "VITE_APP_GOOGLE_MAPS_API_KEY=$(az keyvault secret show --name GOOGLEMAPSAPIKEY --vault-name $KEYVAULT_NAME --query "value" -o tsv)" >> ./frontend/ui/.env
-echo "VITE_SUPABASE_URL=$(az keyvault secret show --name SUPABASEURL --vault-name $KEYVAULT_NAME --query "value" -o tsv)" >> ./frontend/ui/.env
+echo "VITE_SUPABASE_URL=$SUPABASE_URL" >> ./frontend/ui/.env
 echo "VITE_SUPABASE_ANON_KEY=$(az keyvault secret show --name SUPABASEKEY --vault-name $KEYVAULT_NAME --query "value" -o tsv)" >> ./frontend/ui/.env

--- a/nginx.conf
+++ b/nginx.conf
@@ -88,6 +88,14 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location /api/v1/user-management/ {
+            proxy_pass http://user-management:8080/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
 
         error_page 404 /404.html;
         location = /404.html {


### PR DESCRIPTION
This pull request introduces support for a new `user-management` service by updating the `docker-compose.yaml` file and the NGINX configuration. The changes ensure that the service is properly included in the application stack and accessible via the reverse proxy.

### Updates to `docker-compose.yaml`:

* Added the `user-management/docker-compose.yaml` file to the `include` section to integrate the service into the stack.
* Included `user-management` in the `services` section to enable its deployment.

### Updates to `nginx.conf`:

* Added a new location block in the NGINX configuration to route requests to `/api/v1/user-management/` to the `user-management` service, ensuring proper headers are forwarded.