### PR TITLE
Add user-management in revsere-proxy

### DIFF
--- a/nginx.prod.conf
+++ b/nginx.prod.conf
@@ -84,6 +84,14 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location /api/v1/user-management/ {
+            proxy_pass http://user-management:8080/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         error_page 404 /404.html;
         location = /404.html {
             root /usr/share/nginx/html;


### PR DESCRIPTION
This pull request adds a new route configuration to the `nginx.prod.conf` file to enable proxying requests to the user management service.

Routing configuration changes:

* [`nginx.prod.conf`](diffhunk://#diff-0390fb114ed137babe0892eb53d71ac6460eb39d4a822bfe4ed1a2bf52a45734R87-R94): Added a new `location` block for `/api/v1/user-management/` to proxy requests to the `user-management` service running on port 8080. This includes setting headers for `Host`, `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto` to ensure proper forwarding and identification of client requests.