### PR TITLE
Fix mongo login credentials

### DIFF
--- a/docker-compose.prod.override.yaml
+++ b/docker-compose.prod.override.yaml
@@ -8,6 +8,9 @@ services:
   mongo-trip:
     env_file:
       - .env
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGOPASSWORD}
     networks:
       - voyage
     volumes:


### PR DESCRIPTION
This pull request updates the `docker-compose.prod.override.yaml` file to enhance the configuration for the `mongo-trip` service by adding environment variables for database authentication.

Configuration updates:

* [`docker-compose.prod.override.yaml`](diffhunk://#diff-3d528d37048ee90b1c73457625f840a06b57f34dc99d0cf1876c0e99ab546840R11-R13): Added `MONGO_INITDB_ROOT_USERNAME` and `MONGO_INITDB_ROOT_PASSWORD` environment variables to the `mongo-trip` service, allowing for initialization of the MongoDB root user credentials using values from the `.env` file.