### PR TITLE
Add websocket option to reverse-proxy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "user-management"]
 	path = user-management
 	url = git@github.com:voyage-pi/user-management.git
+[submodule "landing-page"]
+	path = landing-page
+	url = git@github.com:voyage-pi/landing-page.git

--- a/nginx.conf
+++ b/nginx.conf
@@ -62,6 +62,12 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # WebSocket support for trip creation
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 86400;
         }
 
         location /api/v1/recommendations/ {

--- a/nginx.prod.conf
+++ b/nginx.prod.conf
@@ -38,6 +38,11 @@ http {
             root /usr/share/nginx/html;
             index index.html index.htm;
             try_files $uri $uri/ /index.html;  # For SPA routing
+            
+            # WebSocket support (if your frontend uses it)
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
         }
 
         location = /favicon.ico {
@@ -58,6 +63,12 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            
+            # WebSocket support for trip creation
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 86400;
         }
 
         location /api/v1/recommendations/ {


### PR DESCRIPTION
This pull request introduces a new submodule for the `landing-page` project and updates the repository configuration accordingly.

Repository configuration updates:

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R19-R21): Added a new submodule for the `landing-page` project with its path and URL specified.
* [`landing-page`](diffhunk://#diff-6097c64ac5d82e7d7861784c466c0e863b23a2ddfbfc809b50934ad282faf643R1): Added a subproject commit reference for the `landing-page` submodule.