### PR TITLE
Add certificates for landing page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     types:
-      - closed  # Trigger when the pull request is closed (i.e., merged)
+      - closed # Trigger when the pull request is closed (i.e., merged)
 
 jobs:
   deploy:
@@ -31,8 +31,9 @@ jobs:
             mkdir certs
             cp ../certs/certificate.crt ./certs/certificate.crt
             cp ../certs/private.key ./certs/private.key
+            cp ../certs/landing_certificate.crt ./certs/landing_certificate.crt
+            cp ../certs/landing_private.key ./certs/landing_private.key
             git submodule update --recursive
             chmod +x deploy.sh
             ./deploy.sh
           EOF
-

--- a/nginx.prod.conf
+++ b/nginx.prod.conf
@@ -118,8 +118,8 @@ http {
         listen 443 ssl;
         server_name landing.voyage-pi.com;
 
-        ssl_certificate /etc/ssl/certificate.crt;
-        ssl_certificate_key /etc/ssl/private.key;
+        ssl_certificate /etc/ssl/landing_certificate.crt;
+        ssl_certificate_key /etc/ssl/landing_private.key;
 
         location / {
             root /usr/share/nginx/html/landing;


### PR DESCRIPTION
This pull request introduces changes to support a separate SSL certificate for the `landing.voyage-pi.com` subdomain. The most important changes include updating the deployment workflow to copy the new certificate files and modifying the NGINX configuration to use these new certificates.

**Deployment workflow updates:**

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R34-L38): Added steps to copy `landing_certificate.crt` and `landing_private.key` into the `certs` directory during deployment.

**NGINX configuration updates:**

* [`nginx.prod.conf`](diffhunk://#diff-0390fb114ed137babe0892eb53d71ac6460eb39d4a822bfe4ed1a2bf52a45734L121-R122): Updated the `ssl_certificate` and `ssl_certificate_key` paths for the `landing.voyage-pi.com` server block to use the new `landing_certificate.crt` and `landing_private.key` files.